### PR TITLE
Add initial rolling stock tracing

### DIFF
--- a/BaseReporter.cs
+++ b/BaseReporter.cs
@@ -79,7 +79,8 @@ namespace DVPathTracer
             {
                 fileName = defaultFilename;
             }
-            File.WriteAllText(basePath + fileName, $"Time,{PlayerReporter.Headings},{StockReporter.Headings},{StockReporter.Headings}\n");
+            File.WriteAllText(basePath + fileName, $"DVPathTracer,{Main.entry.Info.Version}\n");
+            WriteToFile($"Time,{PlayerReporter.Headings},{StockReporter.Headings},{StockReporter.Headings}\n");
             Main.Log($"File {fileName} readied");
         }
 

--- a/BaseReporter.cs
+++ b/BaseReporter.cs
@@ -114,7 +114,7 @@ namespace DVPathTracer
                 }
                 else if (StockFinder.TrackedStock[index].ID == String.Empty) // Car no longer exists
                 {
-                    Main.Log($"Removing deleted car {StockFinder.TrackedStock[index].ID}");
+                    //Main.Log($"Removing deleted car {StockFinder.TrackedStock[index].ID}");
                     report += $"{StockReporter.Headings},";
                     toRemove.Add(index);
                     remainingStock--;

--- a/Settings.cs
+++ b/Settings.cs
@@ -9,6 +9,9 @@ namespace DVPathTracer
         [Draw("Report rate (seconds per report)", Min = 1f)]
         public float logRate = 5f;
 
+        [Draw("Trace freight/passenger cars")]
+        public bool trackFreight = true;
+
         [Draw("Record speed in mph (default: km/h)")]
         public bool mph = false;
 

--- a/StockFinder.cs
+++ b/StockFinder.cs
@@ -85,13 +85,13 @@ namespace DVPathTracer
             TrainCar[] allCars = UnityEngine.Object.FindObjectsOfType<TrainCar>();
             foreach (TrainCar car in allCars)
             {
-                //if (car.IsLoco || car.carType == TrainCarType.CabooseRed)
-                //{
-                    if (!IsTracking(car))
+                if (!IsTracking(car))
+                {
+                    if (Main.settings.trackFreight || car.IsLoco || car.carType == TrainCarType.CabooseRed)
                     {
                         Add(car);
                     }
-                //}
+                }
             }
         }
     }

--- a/StockFinder.cs
+++ b/StockFinder.cs
@@ -85,13 +85,13 @@ namespace DVPathTracer
             TrainCar[] allCars = UnityEngine.Object.FindObjectsOfType<TrainCar>();
             foreach (TrainCar car in allCars)
             {
-                if (car.IsLoco || car.carType == TrainCarType.CabooseRed)
-                {
+                //if (car.IsLoco || car.carType == TrainCarType.CabooseRed)
+                //{
                     if (!IsTracking(car))
                     {
                         Add(car);
                     }
-                }
+                //}
             }
         }
     }

--- a/StockReporter.cs
+++ b/StockReporter.cs
@@ -83,43 +83,27 @@ namespace DVPathTracer
                 }
                 if (type == "")
                 {
-                    type = Target.carType.ToString();
-                }
-                /*switch (Target.carType)
-                {
-                    case TrainCarType.LocoShunter:
-                        type = "DE2";
-                        break;
-                    case TrainCarType.LocoSteamHeavy:
-                        type = "SH282";
-                        break;
-                    case TrainCarType.LocoDiesel:
-                        type = "DE6";
-                        break;
-                    case TrainCarType.CabooseRed:
-                        type = "Caboose";
-                        break;
-                    case TrainCarType.NotSet:
-                    default:
-                        if (Main.cclEnabled)
-                        {
-                            try
-                            {
-                                type = CCLInterface.CustomCarIndentifier(Target.carType);
-                            }
-                            catch //(Exception e)
-                            {
-                                //Main.Log(e.ToString());
-                                // It's either an error or just not CCL stock
-                                // TODO: this better
-                            }
-                        }
-                        if (type == "")
-                        {
+                    switch (Target.carType)
+                    {
+                        case TrainCarType.LocoShunter:
+                            type = "DE2";
+                            break;
+                        case TrainCarType.LocoSteamHeavy:
+                            type = "SH282";
+                            break;
+                        case TrainCarType.LocoDiesel:
+                            type = "DE6";
+                            break;
+                        case TrainCarType.CabooseRed:
+                            type = "Caboose";
+                            break;
+                        case TrainCarType.NotSet:
+                        default:
                             type = Target.carType.ToString();
-                        }
-                        break;
-                }*/
+                            break;
+                    }
+                }
+                
                 return type;
             }
         }

--- a/StockReporter.cs
+++ b/StockReporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using DV.Logic.Job;
 
 // TODO: Learn the what and *why* of C# fields vs properties
 
@@ -18,13 +19,23 @@ namespace DVPathTracer
         }
 
         // C = 'Car' (includes locos)
-        public const string Headings = "CID,CType,CPosX,CPosY,CPosZ,CRotA,CSpd";
+        // Cg = 'Cargo' loaded in car (if applicable)
+        public const string Headings = "CID,CType,CPosX,CPosY,CPosZ,CRotA,CSpd,C%,Cargo,CgTyp,Cg%";
 
         public string Values
         {
             get
             {
-                return $"{ID},{Type},{Position.x},{Position.y - BaseReporter.seaLevel},{Position.z},{Rotation},{SpeedUnits(Speed)}";
+                string values = $"{ID},{Type},{Position.x},{Position.y - BaseReporter.seaLevel},{Position.z},{Rotation},{SpeedUnits(Speed)},{CarHealth}";
+                if (Target.LoadedCargo == CargoType.None)
+                {
+                    values += ",None,N/A,N/A";
+                }
+                else
+                {
+                    values += $",{Cargo},{CargoCategory},{CargoHealth}";
+                }
+                return values;
             }
         }
 
@@ -136,6 +147,72 @@ namespace DVPathTracer
                 Vector3 planeRotation = Vector3.ProjectOnPlane(locoTransform.forward, Vector3.up);
                 float rotationAngle = Mathf.Atan2(planeRotation.x, planeRotation.z) * Mathf.Rad2Deg;
                 return rotationAngle >= 0 ? rotationAngle : 360 + rotationAngle;
+            }
+        }
+
+        /**
+         * Car health, %
+         */
+        public float CarHealth
+        {
+            get
+            {
+                //Main.Log($"Car health of {ID}: {Target.CarDamage.EffectiveHealthPercentage100Notation}");
+                return Target.CarDamage.EffectiveHealthPercentage100Notation;
+            }
+        }
+
+        /**
+         * Cargo health, %
+         */
+        public float CargoHealth
+        {
+            get
+            {
+                //Main.Log($"Cargo health of {ID}: {Target.CargoDamage.EffectiveHealthPercentage100Notation}");
+                return Target.CargoDamage.EffectiveHealthPercentage100Notation;
+            }
+        }
+
+        /**
+         * Cargo name
+         */
+        public string Cargo
+        {
+            get
+            {
+                Main.Log($"Cargo of {ID}: {CargoTypes.GetCargoName(Target.LoadedCargo)}");
+                return CargoTypes.GetCargoName(Target.LoadedCargo);
+            }
+        }
+
+        /**
+         * DVPT-specific human-readable category for use in animator
+         */
+        public string CargoCategory
+        {
+            get
+                // ???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????? idk
+            {
+                return "TODO";
+                /*
+                // Mil>Haz>Inert>Empty if more than one apply
+                if (CargoTypes.Hazmat3Cargo.Contains(Target.LoadedCargo))
+                {
+                    return "HZMT1";
+                }
+                if (CargoTypes.Hazmat3Cargo.Contains(Target.LoadedCargo))
+                {
+                    return "HZMT3";
+                }
+                if (CargoTypes.Hazmat2Cargo.Contains(Target.LoadedCargo))
+                {
+                    return "HZMT2";
+                }
+                if (CargoTypes.Hazmat1Cargo.Contains(Target.LoadedCargo))
+                {
+                    return "HZMT1";
+                }*/
             }
         }
 

--- a/StockReporter.cs
+++ b/StockReporter.cs
@@ -47,7 +47,24 @@ namespace DVPathTracer
             get
             {
                 string type = "";
-                switch (Target.carType)
+                if (Main.cclEnabled)
+                {
+                    try
+                    {
+                        type = CCLInterface.CustomCarIndentifier(Target.carType);
+                    }
+                    catch //(Exception e)
+                    {
+                        //Main.Log(e.ToString());
+                        // It's either an error or just not CCL stock
+                        // TODO: this better
+                    }
+                }
+                if (type == "")
+                {
+                    type = Target.carType.ToString();
+                }
+                /*switch (Target.carType)
                 {
                     case TrainCarType.LocoShunter:
                         type = "DE2";
@@ -81,7 +98,7 @@ namespace DVPathTracer
                             type = Target.carType.ToString();
                         }
                         break;
-                }
+                }*/
                 return type;
             }
         }

--- a/StockReporter.cs
+++ b/StockReporter.cs
@@ -8,10 +8,10 @@ namespace DVPathTracer
 {
     public class StockReporter
     {
-        public TrainCar Target { get; set; }
+        public TrainCar Target { get; private set; }
 
         /**
-         * Rolling stock reporter, reports on the given train car (Currently exclusively a loco or the caboose)
+         * Rolling stock reporter, reports on the given train car (inc. locos, caboose)
          */
         public StockReporter(TrainCar car)
         {
@@ -29,7 +29,16 @@ namespace DVPathTracer
                 string values = $"{ID},{Type},{Position.x},{Position.y - BaseReporter.seaLevel},{Position.z},{Rotation},{SpeedUnits(Speed)},{CarHealth}";
                 if (Target.LoadedCargo == CargoType.None)
                 {
-                    values += ",None,N/A,N/A";
+                    if (CargoTypes.Military1CarContainers.Contains(CargoTypes.CarTypeToContainerType[Target.carType]))
+                    {
+                        // Military 1 licence allows LH jobs of military cars - it's more interesting to class as MIL1 despite being empty
+                        values += ",None,MIL1,N/A";
+                    }
+                    else
+                    {
+                        // Loco, caboose, or otherwise unloaded car
+                        values += ",None,N/A,N/A";
+                    }
                 }
                 else
                 {
@@ -40,6 +49,7 @@ namespace DVPathTracer
         }
 
         /**
+         * In-game ID
          * L-001 etc
          */
         public string ID
@@ -157,7 +167,6 @@ namespace DVPathTracer
         {
             get
             {
-                //Main.Log($"Car health of {ID}: {Target.CarDamage.EffectiveHealthPercentage100Notation}");
                 return Target.CarDamage.EffectiveHealthPercentage100Notation;
             }
         }
@@ -169,37 +178,37 @@ namespace DVPathTracer
         {
             get
             {
-                //Main.Log($"Cargo health of {ID}: {Target.CargoDamage.EffectiveHealthPercentage100Notation}");
                 return Target.CargoDamage.EffectiveHealthPercentage100Notation;
             }
         }
 
         /**
-         * Cargo name
+         * In-game name of the cargo
          */
         public string Cargo
         {
             get
             {
-                Main.Log($"Cargo of {ID}: {CargoTypes.GetCargoName(Target.LoadedCargo)}");
                 return CargoTypes.GetCargoName(Target.LoadedCargo);
             }
         }
 
         /**
-         * DVPT-specific human-readable category for use in animator
+         * DVPT-specific human-readable category of loaded cargo for use in animator
+         * Assumes there is loaded cargo to categorise
          */
         public string CargoCategory
         {
             get
-                // ???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????? idk
             {
-                return "TODO";
-                /*
-                // Mil>Haz>Inert>Empty if more than one apply
-                if (CargoTypes.Hazmat3Cargo.Contains(Target.LoadedCargo))
+                // Mil>Haz if more than one apply
+                if (CargoTypes.Military3Cargo.Contains(Target.LoadedCargo))
                 {
-                    return "HZMT1";
+                    return "MIL3";
+                }
+                if (CargoTypes.Military2Cargo.Contains(Target.LoadedCargo))
+                {
+                    return "MIL2";
                 }
                 if (CargoTypes.Hazmat3Cargo.Contains(Target.LoadedCargo))
                 {
@@ -212,7 +221,8 @@ namespace DVPathTracer
                 if (CargoTypes.Hazmat1Cargo.Contains(Target.LoadedCargo))
                 {
                     return "HZMT1";
-                }*/
+                }
+                return "Inert";
             }
         }
 

--- a/StockReporter.cs
+++ b/StockReporter.cs
@@ -20,7 +20,7 @@ namespace DVPathTracer
 
         // C = 'Car' (includes locos)
         // Cg = 'Cargo' loaded in car (if applicable)
-        public const string Headings = "CID,CType,CPosX,CPosY,CPosZ,CRotA,CSpd,C%,Cargo,CgTyp,Cg%";
+        public const string Headings = "CID,CType,CPosX,CPosY,CPosZ,CRotA,CSpd,C%,CgType,CgCat,Cg%";
 
         public string Values
         {

--- a/pathAnimator/pathAnimator.html
+++ b/pathAnimator/pathAnimator.html
@@ -46,6 +46,92 @@
             </div>
         </div>
         <div class="col-12 p-3" id="legend">
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="Player"></div>
+                <div class="col-4">Player</div>
+                <div class="col-1 legendSpot" id="DE2"></div>
+                <div class="col-4">DE2</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="Caboose"></div>
+                <div class="col-4">Crew Vehicle</div>
+                <div class="col-1 legendSpot" id="DE6"></div>
+                <div class="col-4">DE6</div>
+            </div>
+            <div class="row py-1 pb-3">
+                <div class="col-1 legendSpot" id="Mod"></div>
+                <div class="col-4">Modded Loco</div>
+                <div class="col-1 legendSpot" id="SH282"></div>
+                <div class="col-4">SH282</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="MIL1"></div>
+                <div class="col-1 mx-1 legendSpot" id="MIL2"></div>
+                <div class="col-1 legendSpot" id="MIL3"></div>
+                <div class="col-6">Military 1/2/3</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CFF"></div>
+                <div class="col-1 mx-1 legendSpot" id="CFFL"></div>
+                <div class="col-3">Flatcar</div>
+                <div class="col-1 legendSpot" id="CFS"></div>
+                <div class="col-1 mx-1 legendSpot" id="CFSL"></div>
+                <div class="col-3">With Stakes</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CBX"></div>
+                <div class="col-1 mx-1 legendSpot" id="CBXL"></div>
+                <div class="col-3">Boxcar</div>
+                <div class="col-1 legendSpot" id="CRF"></div>
+                <div class="col-1 mx-1 legendSpot" id="CRFL"></div>
+                <div class="col-3">Refrigerated</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CVT"></div>
+                <div class="col-1 mx-1 legendSpot" id="CVTL"></div>
+                <div class="col-4">Autorack</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CBK"></div>
+                <div class="col-1 mx-1 legendSpot" id="CBKL"></div>
+                <div class="col-8">Hopper/Gondola</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="COL"></div>
+                <div class="col-1 mx-1 legendSpot" id="COLL"></div>
+                <div class="col-8">Oil Tanker</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CGS"></div>
+                <div class="col-1 mx-1 legendSpot" id="CGSL"></div>
+                <div class="col-8">Gas Tanker</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CCH"></div>
+                <div class="col-1 mx-1 legendSpot" id="CCHL"></div>
+                <div class="col-8">Chemical Tanker</div>
+            </div>
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="CPS"></div>
+                <div class="col-1 mx-1 legendSpot" id="CPSL"></div>
+                <div class="col-8">Passenger Car</div>
+            </div>
+            <div class="row py-1 pb-3">
+                <div class="col-1 legendSpot" id="Unknown"></div>
+                <div class="col-1 mx-1 legendSpot" id="UnknownL"></div>
+                <div class="col-8">Unknown Car</div>
+            </div>
+            <!--
+            <div class="row py-1">
+                <div class="col-1 legendSpot" id="Inert"></div>
+                <div class="col-10">Inert Cargo</div>
+            </div>
+            <div class="row py-1 pb-3">
+                <div class="col-1 legendSpot" id="HZMT1"></div>
+                <div class="col-2 mx-1 legendSpot" id="HZMT2"></div>
+                <div class="col-1 legendSpot" id="HZMT3"></div>
+                <div class="col-6">HZMT Cargo</div>
+            </div>-->
         </div>
     </div>
     <div class="col-12 d-none">

--- a/pathAnimator/static/pathAnimator.js
+++ b/pathAnimator/static/pathAnimator.js
@@ -19,7 +19,7 @@ const _playerDataIndices = [
     'ROT'
 ];
 
-const _carDataIndices = [
+const _allCarDataIndices = [
     'CID',
     'TYP',
     'X',
@@ -32,6 +32,8 @@ const _carDataIndices = [
     'CgCAT',
     'Cg%'
 ];
+
+var _carDataIndices = _allCarDataIndices;
 
 const _colours = {
     'Player':  '#1f77b4',
@@ -136,7 +138,8 @@ function interpretFile(fileString) {
     _carData = {};
     let lines = fileString.split('\n');
     console.log(`Reading ${lines.length} lines...`);
-    for (let i=0; i < lines.length; i++) {
+    interpretMetadataLine(lines[0].trim().split(','));
+    for (let i=1; i < lines.length; i++) {
         let elements = lines[i].trim().split(',');
 
         let time = parseInt(elements.splice(0, 1));
@@ -156,7 +159,21 @@ function interpretFile(fileString) {
 }
 
 /**
- * Interprets a substring of data relevant to info about the player
+ * Interprets an array of data about the tracer that created the file
+ */
+function interpretMetadataLine(line) {
+    if (line[0] != 'DVPathTracer') {
+        // Traced path was made using 0.3.0 or earlier
+        console.log("Tracer version: 0.3 or earlier");
+        _carDataIndices = _allCarDataIndices.slice(0,7);
+    } else {
+        console.log(`Tracer version: ${line[1]}`);
+        _carDataIndices = _allCarDataIndices;
+    }
+}
+
+/**
+ * Interprets an array of data relevant to info about the player
  */
 function interpretPlayerLine(time, line) {
     if (line.length < 4 || line[0] == '' || line[0] == 'PPosX') {
@@ -172,7 +189,7 @@ function interpretPlayerLine(time, line) {
 }
 
 /**
- * Interprets a substring of data relevant to info about one piece of rolling stock
+ * Interprets an array of data relevant to info about one piece of rolling stock
  */
 function interpretCarLine(time, line) {
     if (line.length < 6 || line[0] == '' ||  line[0] == 'CID') {

--- a/pathAnimator/static/pathAnimator.js
+++ b/pathAnimator/static/pathAnimator.js
@@ -3,7 +3,7 @@ var _playerData = {}; // Time: [X, Y, Z, ROT]
 var _carData = {};    // CID_TYP: {Time: [X, Y, Z, ROT, SPD]}
 const _idSep = ' ';   //    ^ This symbol here
 
-const _worldDimentions = [16360, 16360];
+const _worldDimensions = [16360, 16360];
 
 var _traces = [];
 var _frames = [];
@@ -261,12 +261,12 @@ function plotData() {
     let layout = {
         showlegend: true,
         xaxis: {
-            range: [0, _worldDimentions[0]],
+            range: [0, _worldDimensions[0]],
             visible: false,
             showgrid: false
         },
         yaxis: {
-            range: [0, _worldDimentions[1]],
+            range: [0, _worldDimensions[1]],
             scaleanchor: 'x',
             visible: false,
             showgrid: false
@@ -367,12 +367,12 @@ function animateData() {
         mode: 'markers'
     }], {
         xaxis: {
-            range: [0, _worldDimentions[0]],
+            range: [0, _worldDimensions[0]],
             visible: false,
             showgrid: false
         },
         yaxis: {
-            range: [0, _worldDimentions[1]],
+            range: [0, _worldDimensions[1]],
             scaleanchor: 'x',
             visible: false,
             showgrid: false
@@ -407,9 +407,9 @@ function addBackgroundImage() {
                 'xref': 'x',
                 'yref': 'y',
                 'x': 0,
-                'y': _worldDimentions[1],
-                'sizex': _worldDimentions[0],
-                'sizey': _worldDimentions[1],
+                'y': _worldDimensions[1],
+                'sizex': _worldDimensions[0],
+                'sizey': _worldDimensions[1],
                 'sizing': 'stretch',
                 'opacity': 0.6,
                 'layer': 'below'

--- a/pathAnimator/static/pathAnimator.js
+++ b/pathAnimator/static/pathAnimator.js
@@ -80,7 +80,7 @@ const _colours = {
     'CPS':      '#a3a3ff', // Passenger car
     'CPSL':     '#7879ff',
 
-    'Unknown':  '#9969c7', // (usually) A modded car that was assigned the C (crew) prefix, rather than one of the triples above
+    'Unknown':  '#9969c7', // (usually) A modded car that was assigned the generic C prefix, rather than one of the triples above
     'UnknownL': '#6a359c'
 };
 
@@ -200,7 +200,7 @@ function interpretFile(fileString) {
 function interpretMetadataLine(line) {
     if (line[0] != 'DVPathTracer') {
         // Traced path was made using 0.3.0 or earlier
-        console.log("Tracer version: 0.3 or earlier");
+        console.log("Tracer version: 0.3.0 or earlier");
         _carDataIndices = _allCarDataIndices.slice(0,5);
         _tracerVersion = 0;
     } else {

--- a/pathAnimator/static/pathAnimator.js
+++ b/pathAnimator/static/pathAnimator.js
@@ -28,8 +28,8 @@ const _carDataIndices = [
     'ROT',
     'SPD',
     'C%',
-    'Cg',
     'CgTYP',
+    'CgCAT',
     'Cg%'
 ];
 

--- a/pathAnimator/static/pathAnimator.js
+++ b/pathAnimator/static/pathAnimator.js
@@ -1,6 +1,6 @@
 // Dictionaries for player & rolling stock data
 var _playerData = {}; // Time: [X, Y, Z, ROT]
-var _carData = {};    // CID_TYP: {Time: [X, Y, Z, ROT, SPD]}
+var _carData = {};    // CID_TYP: {Time: [X, Y, Z, ROT, SPD, H, CgTYP, CgCAT, CgH]}
 const _idSep = ' ';   //    ^ This symbol here
 
 const _worldDimensions = [16360, 16360];
@@ -11,6 +11,8 @@ var _frame = 0;
 var _numFrames = 0;
 var _fps = 24;
 var _animating = false;
+// Each major version indicates a change/addition to the columns of data created
+var _tracerVersion;
 
 const _playerDataIndices = [
     'X',
@@ -20,29 +22,66 @@ const _playerDataIndices = [
 ];
 
 const _allCarDataIndices = [
-    'CID',
-    'TYP',
-    'X',
-    'Y',
-    'Z',
-    'ROT',
-    'SPD',
-    'C%',
-    'CgTYP',
-    'CgCAT',
-    'Cg%'
+    //'CID',
+    //'TYP',
+    'X',    // ----------
+    'Y',    // - v0+
+    'Z',    // -
+    'ROT',  // -
+    'SPD',  // ----------
+    'H',    // ----------
+    'CgTYP',// - v1+
+    'CgCAT',// -
+    'CgH'   // ----------
 ];
 
 var _carDataIndices = _allCarDataIndices;
 
 const _colours = {
-    'Player':  '#1f77b4',
-    'Caboose': '#d62728',
-    'DE2':     '#ff7f0e',
-    'DE6':     '#8c564b',
-    'SH282':   '#111111',
-    'Tender':  '#111111',
-    'Mod':     '#2ca02c'
+    'Player':   '#1f77b4',
+    'Caboose':  '#d62728',
+    'HandCar':  '#d62728',
+    'DE2':      '#ff6600',
+    'DE6':      '#7e5c3a',
+    'SH282':    '#111111',
+    'Tender':   '#111111',
+    'Mod':      '#c5558e',
+
+    'MIL1':     '#79c633',
+    'MIL2':     '#68aa2c',
+    'MIL3':     '#568d42',
+    // CXN - nuclear flask
+    // CXB - mil. boxcar
+    // CXF - mil. flatcar
+
+    // 'HZMT1':    '#ffa80f',
+    // 'HZMT2':    '#fe8116',
+    // 'HZMT3':    '#fe5a1d',
+    // 'Inert':    '#696969',
+
+    'CFF':      '#bdbdbd', // flatbed
+    'CFFL':     '#8b8b8b',
+    'CFS':      '#bdbdbd', // flatbed with stakes
+    'CFSL':     '#696969',
+    'CVT':      '#eeb609', // car car
+    'CVTL':     '#c69320', // car car with cars
+    'CBK':      '#fcb033', // gondola/hopper
+    'CBKL':     '#fa8607',
+    'CBX':      '#b5651d', // boxcar
+    'CBXL':     '#964b00',
+    'CRF':      '#b5651d', // refrigerated boxcar
+    'CRFL':     '#673400',
+    'CGS':      '#e6c16a', // gas tanker (orange/blue)
+    'CGSL':     '#ce9f56',
+    'CCH':      '#c34632', // chemical tanker (black)
+    'CCHL':     '#9e1711',
+    'COL':      '#555555', // oil tanker (white/chrome)
+    'COLL':     '#333333',
+    'CPS':      '#a3a3ff', // Passenger car
+    'CPSL':     '#7879ff',
+
+    'Unknown':  '#9969c7', // (usually) A modded car that was assigned the C (crew) prefix, rather than one of the triples above
+    'UnknownL': '#6a359c'
 };
 
 $(document).ready(function() {
@@ -70,14 +109,11 @@ $(document).ready(function() {
         }
     });
 
-    // Build the Key/Legend
-    for (let i in Object.keys(_colours)) {
-        let item = Object.keys(_colours)[i];
-        let element =   '<div class="row py-1">' +
-                            `<div class="col-2 legendSpot" style="background-color:${_colours[item]}"></div>` +
-                            `<div class="col-10">${item}</div>` +
-                        '</div>';
-        $('#legend').append(element);
+    // Colour the Key/Legend
+    let colourKeys = Object.keys(_colours);
+    for (let i=0; i < colourKeys.length; i++) {
+        let spot = colourKeys[i];
+        $('#' + spot).css("background-color", _colours[spot]);
     }
 
     // Create FPS slider
@@ -149,7 +185,7 @@ function interpretFile(fileString) {
 
         // Deal with the car(s) data
         while (elements.length > 0) {
-            interpretCarLine(time, elements.splice(0, _carDataIndices.length));
+            interpretCarLine(time, elements.splice(0, _carDataIndices.length + 2));
         }
     }
     _traces = getPlottableTraces();
@@ -165,10 +201,12 @@ function interpretMetadataLine(line) {
     if (line[0] != 'DVPathTracer') {
         // Traced path was made using 0.3.0 or earlier
         console.log("Tracer version: 0.3 or earlier");
-        _carDataIndices = _allCarDataIndices.slice(0,7);
+        _carDataIndices = _allCarDataIndices.slice(0,5);
+        _tracerVersion = 0;
     } else {
         console.log(`Tracer version: ${line[1]}`);
         _carDataIndices = _allCarDataIndices;
+        _tracerVersion = 1;
     }
 }
 
@@ -204,6 +242,14 @@ function interpretCarLine(time, line) {
         parseFloat(line[5]),
         parseFloat(line[6])
     ];
+    if (_tracerVersion >= 1) {
+        result.push(
+            parseFloat(line[7]),
+            line[8],
+            line[9],
+            parseFloat(line[10])
+        );
+    }
     if (!_carData[idType]) {
         _carData[idType] = {};
     }
@@ -236,14 +282,19 @@ function getPlottableTraces() {
     });
     for (let i=0; i < orderedPlayerKeys.length; i++) {
         let key = orderedPlayerKeys[i];
-        last(dataPlot).x.push(_playerData[key][0]); // X
-        last(dataPlot).y.push(_playerData[key][2]); // Z
+        last(dataPlot).x.push(_playerData[key][_playerDataIndices.indexOf('X')]);
+        last(dataPlot).y.push(_playerData[key][_playerDataIndices.indexOf('Z')]);
     }
 
     for (let carID in _carData) {
+        // Don't include freight/passenger cars in the static trace
+        if (!carID.startsWith('L') && !carID.includes('Caboose')) {
+            continue;
+        }
         let car = _carData[carID];
         let orderedCarKeys = Object.keys(car).sort((a, b) => a - b);
         let carType = carID.split(_idSep)[1];
+        let spotColour = _colours[carType] ? _colours[carType] : _colours['Mod'];
         dataPlot.push({
             x: [], y: [],
             name: carID,
@@ -251,17 +302,17 @@ function getPlottableTraces() {
             mode: 'lines+markers',
             line: {
                 width: 3,
-                color: _colours[carType] ? _colours[carType] : _colours['Mod']
+                color: spotColour
             },
             marker: {
                 size: 3,
-                color: _colours[carType] ? _colours[carType] : _colours['Mod']
+                color: spotColour
             }
         });
         for (let i=0; i < orderedCarKeys.length; i++) {
             let key = orderedCarKeys[i];
-            last(dataPlot).x.push(car[key][0]); // X
-            last(dataPlot).y.push(car[key][2]); // Z
+            last(dataPlot).x.push(car[key][_carDataIndices.indexOf('X')]);
+            last(dataPlot).y.push(car[key][_carDataIndices.indexOf('Z')]);
         }
     }
 
@@ -313,10 +364,10 @@ function getPlottableFrames() {
     let orderedPlayerKeys = Object.keys(_playerData).sort((a, b) => a - b);
     for (i=0; i < orderedPlayerKeys.length; i++) {
         let recordTime = orderedPlayerKeys[i];
-        // Each frame is a scatter plot of every player & loco
+        // Each frame is a scatter plot of every player & piece of rolling stock
         let dataPlot = {
-            x: [_playerData[recordTime][0]], // X
-            y: [_playerData[recordTime][2]], // Z
+            x: [_playerData[recordTime][_playerDataIndices.indexOf('X')]],
+            y: [_playerData[recordTime][_playerDataIndices.indexOf('Z')]],
             color: [_colours['Player']]
         };
 
@@ -324,10 +375,23 @@ function getPlottableFrames() {
             let car = _carData[carID];
             // If there is a record for this car at this time:
             if (car[recordTime]) {
-                dataPlot.x.push(car[recordTime][0]); // X
-                dataPlot.y.push(car[recordTime][2]); // Z
+                dataPlot.x.push(car[recordTime][_carDataIndices.indexOf('X')]);
+                dataPlot.y.push(car[recordTime][_carDataIndices.indexOf('Z')]);
                 let carType = carID.split(_idSep)[1];
-                dataPlot.color.push(_colours[carType] ? _colours[carType] : _colours['Mod']);
+                let spotColour = _colours[carType] ? _colours[carType] : _colours['Mod'];
+                if (_tracerVersion >= 1 && !carID.startsWith('L') && !carID.includes('Caboose') && !carID.includes('Tender') && !carID.includes('HandCar')) {
+                    // Pick out military cargo, then sort the rest into groups
+                    let cargoCategory = car[recordTime][_carDataIndices.indexOf('CgCAT')];
+                    if (['MIL1', 'MIL2', 'MIL3'].includes(cargoCategory)) {
+                        spotColour = _colours[cargoCategory];
+                    } else {
+                        // Group by car type
+                        let cgSuffix = car[recordTime][_carDataIndices.indexOf('CgTYP')] == 'None' ? '' : 'L';
+                        let subID = carID.substring(0, 3);
+                        spotColour = _colours[subID] ? _colours[subID + cgSuffix] : _colours['Unknown' + cgSuffix];
+                    }
+                }
+                dataPlot.color.push(spotColour);
             }
         }
         dataFrames.push(dataPlot);

--- a/pathAnimator/static/pathAnimator.js
+++ b/pathAnimator/static/pathAnimator.js
@@ -26,7 +26,11 @@ const _carDataIndices = [
     'Y',
     'Z',
     'ROT',
-    'SPD'
+    'SPD',
+    'C%',
+    'Cg',
+    'CgTYP',
+    'Cg%'
 ];
 
 const _colours = {
@@ -35,6 +39,7 @@ const _colours = {
     'DE2':     '#ff7f0e',
     'DE6':     '#8c564b',
     'SH282':   '#111111',
+    'Tender':  '#111111',
     'Mod':     '#2ca02c'
 };
 


### PR DESCRIPTION
Resolves #1 

- Add tracing of all remaining rolling stock

- Add 4 columns of data to all cars & locos:
  - Health (%)
  - Cargo (If applicable)

  Where Cargo is:
  - Cargo name (general vanilla ID)
  - Cargo category (DVPT-specific - MIL, HZMT, Inert)
  - Cargo health (%)

  The cargo category is partially used in conjunction with the original car name for rendering in the animator

- Update the animator to display the new information
  - Cars are grouped by their three-character prefix (CFF, CBX etc), or by Military hazard level (MIL1-3)